### PR TITLE
overlay: Define Google Assistant as default

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -97,4 +97,8 @@
     <string-array name="config_fontPackages" translatable="false">
         <item>com.viper.fonts</item>
     </string-array>
+
+    <!-- Component name for default assistant on this device -->
+    <string name="config_defaultAssistantComponentName">com.google.android.googlequicksearchbox/com.google.android.voiceinteraction.GsaVoiceInteractionService</string>
+
 </resources>


### PR DESCRIPTION
Google introduced that on r21 patch

https://github.com/PixelExperience/frameworks_base/commit/7105e37a8c6d4dcf95695298486b25b8c43a6a7e and https://github.com/PixelExperience/frameworks_base/commit/3a1a64c045ffe89823d8cf2df17655d119f967ba

Change-Id: I28a8d1c9a5c404c5491bfa9d521f2f99c67335cf